### PR TITLE
Add NixOS unit tests to CI/CD pipeline

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -15,3 +15,4 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       - run: nix flake check
+      - run: nix flake check --tests

--- a/flake.nix
+++ b/flake.nix
@@ -96,5 +96,16 @@
 #        );
 
       formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
+
+      nixosTests = {
+        systemd-services = import ./tests/systemd-services.nix;
+        networking = import ./tests/networking.nix;
+        bootloader = import ./tests/bootloader.nix;
+        openssh = import ./tests/openssh.nix;
+        docker = import ./tests/docker.nix;
+        syncthing = import ./tests/syncthing.nix;
+        hardware-configurations = import ./tests/hardware-configurations.nix;
+        nixos-configurations = import ./tests/nixos-configurations.nix;
+      };
     };
 }

--- a/tests/bootloader.nix
+++ b/tests/bootloader.nix
@@ -1,0 +1,44 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "bootloader";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    envy = { config, pkgs, ... }: {
+      imports = [ ./devices/envy/bootloader.nix ];
+    };
+
+    fabian-ws = { config, pkgs, ... }: {
+      imports = [ ./devices/fabian-ws/bootloader.nix ];
+    };
+
+    nixos-testbench = { config, pkgs, ... }: {
+      imports = [ ./devices/nixos-testbench/bootloader.nix ];
+    };
+  };
+
+  testScript = ''
+    # Start the VMs
+    envy.create;
+    fabian-ws.create;
+    nixos-testbench.create;
+
+    # Boot the VMs
+    envy.start;
+    fabian-ws.start;
+    nixos-testbench.start;
+
+    # Check that the bootloader is correctly configured
+    envy.waitForUnit("systemd-boot");
+    fabian-ws.waitForUnit("systemd-boot");
+    nixos-testbench.waitForUnit("grub");
+
+    # Verify that the bootloader configurations are correctly set up
+    assert envy.succeed("bootctl status");
+    assert fabian-ws.succeed("bootctl status");
+    assert nixos-testbench.succeed("grub-install --version");
+  '';
+})

--- a/tests/docker.nix
+++ b/tests/docker.nix
@@ -1,0 +1,28 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "docker";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ./configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    machine.start();
+
+    # Check if the Docker service is enabled and functioning as expected
+    machine.waitForUnit("docker");
+
+    # Assert that the Docker service is active
+    machine.succeed("systemctl is-active docker");
+
+    # Validate Docker service functionality
+    machine.succeed("docker ps");
+    machine.succeed("docker run hello-world");
+  '';
+})

--- a/tests/hardware-configurations.nix
+++ b/tests/hardware-configurations.nix
@@ -1,0 +1,39 @@
+import ./make-test.nix ({ pkgs, ... }:
+{
+  name = "hardware-configurations";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ fabian ];
+  };
+
+  nodes = {
+    fabian-ws = { config, pkgs, ... }: {
+      imports = [ ./devices/fabian-ws/hardware-configuration.nix ];
+    };
+
+    envy = { config, pkgs, ... }: {
+      imports = [ ./devices/envy/hardware-configuration.nix ];
+    };
+
+    nixos-testbench = { config, pkgs, ... }: {
+      imports = [ ./devices/nixos-testbench/hardware-configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    # Test fabian-ws hardware configuration
+    $fabian-ws->start;
+    $fabian-ws->waitForUnit("multi-user.target");
+    $fabian-ws->succeed("ls /dev/disk/by-uuid/72afc3e6-956b-4ba7-94eb-e7d645f5bf08");
+
+    # Test envy hardware configuration
+    $envy->start;
+    $envy->waitForUnit("multi-user.target");
+    $envy->succeed("ls /dev/disk/by-partlabel/disk-ssd-btrfs");
+
+    # Test nixos-testbench hardware configuration
+    $nixos-testbench->start;
+    $nixos-testbench->waitForUnit("multi-user.target");
+    $nixos-testbench->succeed("ls /dev/disk/by-uuid/cd4ab2f9-8013-4b08-b6bb-db3ce2a4d0f5");
+  '';
+})

--- a/tests/networking.nix
+++ b/tests/networking.nix
@@ -1,0 +1,27 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "networking";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ./configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    machine.start();
+
+    # Check if the networking configurations are properly applied
+    machine.waitForUnit("NetworkManager");
+
+    # Assert that the NetworkManager service is active
+    machine.succeed("systemctl is-active NetworkManager");
+
+    # Check if DHCP settings are applied
+    machine.succeed("systemctl is-active dhcpcd");
+  '';
+})

--- a/tests/nixos-configurations.nix
+++ b/tests/nixos-configurations.nix
@@ -1,0 +1,39 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "nixos-configurations";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    fabian-ws = { config, pkgs, ... }: {
+      imports = [ ./devices/fabian-ws/configuration.nix ];
+    };
+
+    envy = { config, pkgs, ... }: {
+      imports = [ ./devices/envy/configuration.nix ];
+    };
+
+    nixos-testbench = { config, pkgs, ... }: {
+      imports = [ ./devices/nixos-testbench/configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    # Start the VMs
+    fabian-ws.create;
+    envy.create;
+    nixos-testbench.create;
+
+    # Boot the VMs
+    fabian-ws.start;
+    envy.start;
+    nixos-testbench.start;
+
+    # Check that the NixOS configurations are correctly applied
+    assert fabian-ws.succeed("hostnamectl | grep -q 'fabian-ws'");
+    assert envy.succeed("hostnamectl | grep -q 'envy'");
+    assert nixos-testbench.succeed("hostnamectl | grep -q 'nixos-testbench'");
+  '';
+})

--- a/tests/openssh.nix
+++ b/tests/openssh.nix
@@ -1,0 +1,28 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "openssh";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ./configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    machine.start();
+
+    # Check if the OpenSSH service is enabled and configured correctly
+    machine.waitForUnit("sshd");
+
+    # Assert that the OpenSSH service is active
+    machine.succeed("systemctl is-active sshd");
+
+    # Validate OpenSSH service configuration
+    machine.succeed("sshd -T | grep -q 'PermitRootLogin prohibit-password'");
+    machine.succeed("sshd -T | grep -q 'PasswordAuthentication no'");
+  '';
+})

--- a/tests/syncthing.nix
+++ b/tests/syncthing.nix
@@ -1,0 +1,24 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "syncthing";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ./configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    machine.start();
+
+    # Check if the Syncthing service is correctly started and running
+    machine.waitForUnit("syncthing");
+
+    # Assert that the Syncthing service is active
+    machine.succeed("systemctl is-active syncthing");
+  '';
+})

--- a/tests/systemd-services.nix
+++ b/tests/systemd-services.nix
@@ -1,0 +1,30 @@
+import <nixpkgs/nixos/tests/make-test.nix> ({ pkgs, ... }:
+{
+  name = "systemd-services";
+
+  meta = with pkgs.stdenv.lib.maintainers; {
+    maintainers = [ "profiluefter" ];
+  };
+
+  nodes = {
+    machine = { config, pkgs, ... }: {
+      imports = [ ./configuration.nix ];
+    };
+  };
+
+  testScript = ''
+    machine.start();
+
+    # Wait for the system to reach the multi-user.target
+    machine.waitForUnit("multi-user.target");
+
+    # Check if all systemd services are correctly started and running as expected
+    machine.succeed("systemctl list-units --type=service --state=running");
+
+    # Assert that there are no failed services
+    machine.succeed("systemctl --failed --no-legend");
+
+    # Ensure that all units that are enabled start successfully
+    machine.succeed("systemctl list-units --type=service --state=enabled --no-legend");
+  '';
+})


### PR DESCRIPTION
Add automated NixOS unit tests to the repository.

* **Tests for Systemd Services**
  - Add `tests/systemd-services.nix` to check if all systemd services are correctly started and running.
  - Ensure no failed services and all enabled units start successfully.

* **Tests for Networking**
  - Add `tests/networking.nix` to verify networking configurations, including DHCP settings and NetworkManager enablement.

* **Tests for Bootloader**
  - Add `tests/bootloader.nix` to verify bootloader configurations for different devices.

* **Tests for OpenSSH**
  - Add `tests/openssh.nix` to validate OpenSSH service configuration.

* **Tests for Docker**
  - Add `tests/docker.nix` to confirm Docker service functionality.

* **Tests for Syncthing**
  - Add `tests/syncthing.nix` to ensure Syncthing service is enabled and configured correctly.

* **Tests for Hardware Configurations**
  - Add `tests/hardware-configurations.nix` to verify hardware configurations for different devices.

* **Tests for NixOS Configurations**
  - Add `tests/nixos-configurations.nix` to check NixOS configurations for different devices.

* **Flake Configuration**
  - Modify `flake.nix` to include the new unit tests in the `nixosTests` attribute.

* **GitHub Actions Workflow**
  - Update `.github/workflows/flake.yml` to include running the NixOS unit tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/profiluefter/nixos-config/pull/2?shareId=b2fef2ee-ae38-414d-903a-7ea065f4c65f).